### PR TITLE
Breaking changes for v0.2.0

### DIFF
--- a/trigger.go
+++ b/trigger.go
@@ -69,7 +69,7 @@ type Trigger struct {
 // TriggerThreshold represents the threshold of a trigger.
 type TriggerThreshold struct {
 	Op    TriggerThresholdOp `json:"op"`
-	Value *float64           `json:"value"`
+	Value float64            `json:"value"`
 }
 
 // TriggerThresholdOp the operator of the trigger threshold.

--- a/trigger_test.go
+++ b/trigger_test.go
@@ -48,7 +48,7 @@ func TestTriggers(t *testing.T) {
 			Frequency: 300,
 			Threshold: &TriggerThreshold{
 				Op:    TriggerThresholdOpGreaterThan,
-				Value: Float64Ptr(10000),
+				Value: 10000,
 			},
 			Recipients: []TriggerRecipient{
 				{

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -5,11 +5,6 @@ func CalculationOpPtr(v CalculationOp) *CalculationOp {
 	return &v
 }
 
-// Float64Ptr returns a pointer to the given float64.
-func Float64Ptr(v float64) *float64 {
-	return &v
-}
-
 // IntPtr returns a pointer to the given int.
 func IntPtr(v int) *int {
 	return &v


### PR DESCRIPTION
- `TriggerThreshold`.`Value` is required, so it shouldn't be a `*float64`