### PR TITLE
Introduce new APIs: Columns, Derived Columns, Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is an API client for the [Honeycomb.io management APIs](https://docs.honeyc
 Supported APIs:
 
 - [Boards API](https://docs.honeycomb.io/api/boards-api/)
+- [Columns API](https://docs.honeycomb.io/api/columns/)
 - [Markers API](https://docs.honeycomb.io/api/markers/)
 - [Triggers API](https://docs.honeycomb.io/api/triggers/)
 - [Query Specification](https://docs.honeycomb.io/api/query-specification/)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supported APIs:
 
 - [Boards API](https://docs.honeycomb.io/api/boards-api/)
 - [Columns API](https://docs.honeycomb.io/api/columns/)
+- [Datasets API](https://docs.honeycomb.io/api/datasets/)
 - [Derived Columns API](https://docs.honeycomb.io/api/derived_columns/)
 - [Markers API](https://docs.honeycomb.io/api/markers/)
 - [Triggers API](https://docs.honeycomb.io/api/triggers/)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supported APIs:
 
 - [Boards API](https://docs.honeycomb.io/api/boards-api/)
 - [Columns API](https://docs.honeycomb.io/api/columns/)
+- [Derived Columns API](https://docs.honeycomb.io/api/derived_columns/)
 - [Markers API](https://docs.honeycomb.io/api/markers/)
 - [Triggers API](https://docs.honeycomb.io/api/triggers/)
 - [Query Specification](https://docs.honeycomb.io/api/query-specification/)

--- a/client.go
+++ b/client.go
@@ -62,10 +62,11 @@ type Client struct {
 	userAgent  string
 	httpClient *http.Client
 
-	Boards   Boards
-	Columns  Columns
-	Markers  Markers
-	Triggers Triggers
+	Boards         Boards
+	Columns        Columns
+	DerivedColumns DerivedColumns
+	Markers        Markers
+	Triggers       Triggers
 }
 
 // NewClient creates a new Honeycomb API client.
@@ -94,6 +95,7 @@ func NewClient(config *Config) (*Client, error) {
 	}
 	client.Boards = &boards{client: client}
 	client.Columns = &columns{client: client}
+	client.DerivedColumns = &derivedColumns{client: client}
 	client.Markers = &markers{client: client}
 	client.Triggers = &triggers{client: client}
 

--- a/client.go
+++ b/client.go
@@ -64,6 +64,7 @@ type Client struct {
 
 	Boards         Boards
 	Columns        Columns
+	Datasets       Datasets
 	DerivedColumns DerivedColumns
 	Markers        Markers
 	Triggers       Triggers
@@ -95,6 +96,7 @@ func NewClient(config *Config) (*Client, error) {
 	}
 	client.Boards = &boards{client: client}
 	client.Columns = &columns{client: client}
+	client.Datasets = &datasets{client: client}
 	client.DerivedColumns = &derivedColumns{client: client}
 	client.Markers = &markers{client: client}
 	client.Triggers = &triggers{client: client}

--- a/client.go
+++ b/client.go
@@ -63,6 +63,7 @@ type Client struct {
 	httpClient *http.Client
 
 	Boards   Boards
+	Columns  Columns
 	Markers  Markers
 	Triggers Triggers
 }
@@ -92,6 +93,7 @@ func NewClient(config *Config) (*Client, error) {
 		httpClient: httpClient,
 	}
 	client.Boards = &boards{client: client}
+	client.Columns = &columns{client: client}
 	client.Markers = &markers{client: client}
 	client.Triggers = &triggers{client: client}
 

--- a/column.go
+++ b/column.go
@@ -1,0 +1,109 @@
+package honeycombio
+
+import (
+	"context"
+	"fmt"
+)
+
+// Columns describe all the columns-related methods that the Honeycomb API
+// supports.
+//
+// API docs: https://docs.honeycomb.io/api/columns/
+type Columns interface {
+	// List all columns in this dataset.
+	List(ctx context.Context, dataset string) ([]Column, error)
+
+	// Get a column by its ID. Returns ErrNotFound if there is no column with
+	// the given ID in this dataset.
+	Get(ctx context.Context, dataset string, id string) (*Column, error)
+
+	// GetByKeyName searches a column by its key name. Returns ErrNotFound if
+	// there is no column with the given key name in this dataset.
+	GetByKeyName(ctx context.Context, dataset string, keyName string) (*Column, error)
+
+	// Create a new column in this dataset. When creating a new column ID may
+	// not be set. The KeyName must be unique for this dataset.
+	Create(ctx context.Context, dataset string, c *Column) (*Column, error)
+
+	// Update an existing column.
+	Update(ctx context.Context, dataset string, c *Column) (*Column, error)
+
+	// Delete a column.
+	Delete(ctx context.Context, dataset string, id string) error
+}
+
+// columns implements Columns.
+type columns struct {
+	client *Client
+}
+
+// Compile-time proof of interface implementation by type columns.
+var _ Columns = (*columns)(nil)
+
+// Column represents a Honeycomb column in a dataset.
+//
+// API docs: https://docs.honeycomb.io/api/columns/#fields-on-a-column
+type Column struct {
+	ID string `json:"id,omitempty"`
+
+	// Name of the column, this field is required.
+	KeyName string `json:"key_name"`
+	// Deprecated, optional.
+	Alias string `json:"alias,omitempty"`
+	// Optional, defaults to false.
+	Hidden *bool `json:"hidden,omitempty"`
+	// Optional.
+	Description string `json:"description,omitempty"`
+	// Optional, defaults to string.
+	Type *ColumnType `json:"type,omitempty"`
+}
+
+// ColumnType determines the type of column.
+type ColumnType string
+
+// Declaration of column types.
+const (
+	ColumnTypeString  ColumnType = "string"
+	ColumnTypeFloat   ColumnType = "float"
+	ColumnTypeInteger ColumnType = "integer"
+	ColumnTypeBoolean ColumnType = "boolean"
+)
+
+// ColumnTypes returns an exhaustive list of column types.
+func ColumnTypes() []ColumnType {
+	return []ColumnType{ColumnTypeString, ColumnTypeFloat, ColumnTypeInteger, ColumnTypeBoolean}
+}
+
+func (s *columns) List(ctx context.Context, dataset string) ([]Column, error) {
+	var c []Column
+	err := s.client.performRequest(ctx, "GET", "/1/columns/"+urlEncodeDataset(dataset), nil, &c)
+	return c, err
+}
+
+func (s *columns) Get(ctx context.Context, dataset string, id string) (*Column, error) {
+	var c Column
+	err := s.client.performRequest(ctx, "GET", fmt.Sprintf("/1/columns/%s/%s", urlEncodeDataset(dataset), id), nil, &c)
+	return &c, err
+}
+
+func (s *columns) GetByKeyName(ctx context.Context, dataset string, keyName string) (*Column, error) {
+	var c Column
+	err := s.client.performRequest(ctx, "GET", fmt.Sprintf("/1/columns/%s?key_name=%s", urlEncodeDataset(dataset), keyName), nil, &c)
+	return &c, err
+}
+
+func (s *columns) Create(ctx context.Context, dataset string, data *Column) (*Column, error) {
+	var c Column
+	err := s.client.performRequest(ctx, "POST", "/1/columns/"+urlEncodeDataset(dataset), data, &c)
+	return &c, err
+}
+
+func (s *columns) Update(ctx context.Context, dataset string, data *Column) (*Column, error) {
+	var c Column
+	err := s.client.performRequest(ctx, "PUT", fmt.Sprintf("/1/columns/%s/%s", urlEncodeDataset(dataset), data.ID), data, &c)
+	return &c, err
+}
+
+func (s *columns) Delete(ctx context.Context, dataset string, id string) error {
+	return s.client.performRequest(ctx, "DELETE", fmt.Sprintf("/1/columns/%s/%s", urlEncodeDataset(dataset), id), nil, nil)
+}

--- a/column_test.go
+++ b/column_test.go
@@ -1,0 +1,83 @@
+package honeycombio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColumns(t *testing.T) {
+	ctx := context.Background()
+
+	c := newTestClient(t)
+	dataset := testDataset(t)
+
+	var column *Column
+	var err error
+
+	t.Run("Create", func(t *testing.T) {
+		data := &Column{
+			KeyName:     "column_test",
+			Hidden:      BoolPtr(false),
+			Description: "This column is created by a test",
+			Type:        ColumnTypePtr(ColumnTypeFloat),
+		}
+		column, err = c.Columns.Create(ctx, dataset, data)
+
+		assert.NoError(t, err)
+
+		data.ID = column.ID
+		assert.Equal(t, data, column)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		columns, err := c.Columns.List(ctx, dataset)
+
+		assert.NoError(t, err)
+		assert.Contains(t, columns, *column, "could not find column with List")
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		result, err := c.Columns.Get(ctx, dataset, column.ID)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *column, *result)
+	})
+
+	t.Run("GetByKeyName", func(t *testing.T) {
+		result, err := c.Columns.GetByKeyName(ctx, dataset, "column_test")
+
+		assert.NoError(t, err)
+		assert.Equal(t, *column, *result)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		// change all the fields to test
+		data := &Column{
+			ID:          column.ID,
+			KeyName:     "a-new-keyname",
+			Hidden:      BoolPtr(true),
+			Description: "This is a new description",
+			Type:        ColumnTypePtr(ColumnTypeBoolean),
+		}
+		column, err = c.Columns.Update(ctx, dataset, data)
+
+		assert.NoError(t, err)
+
+		data.ID = column.ID
+		assert.Equal(t, data, column)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		err = c.Columns.Delete(ctx, dataset, column.ID)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("Get_notFound", func(t *testing.T) {
+		_, err := c.Columns.Get(ctx, dataset, column.ID)
+
+		assert.Equal(t, ErrNotFound, err)
+	})
+}

--- a/dataset.go
+++ b/dataset.go
@@ -1,0 +1,56 @@
+package honeycombio
+
+import (
+	"context"
+)
+
+// Datasets describes all the dataset-related methods that the Honeycomb API
+// supports.
+//
+// API docs: https://docs.honeycomb.io/api/datasets/
+type Datasets interface {
+	// List all datasets.
+	List(ctx context.Context) ([]Dataset, error)
+
+	// Get a dataset by its slug. Returns ErrNotFound if there is no dataset
+	// with the given slug.
+	Get(ctx context.Context, slug string) (*Dataset, error)
+
+	// Create a new dataset. Only name should be set when creating a dataset,
+	// all other fields are ignored.
+	Create(ctx context.Context, dataset *Dataset) (*Dataset, error)
+}
+
+// datasets implements Datasets.
+type datasets struct {
+	client *Client
+}
+
+// Compile-time proof of interface implementation by type datasets.
+var _ Datasets = (*datasets)(nil)
+
+// Dataset represents a Honeycomb dataset.
+//
+// API docs: https://docs.honeycomb.io/api/dataset
+type Dataset struct {
+	Name string `json:"name"`
+	Slug string `json:"slug,omitempty"`
+}
+
+func (s datasets) List(ctx context.Context) ([]Dataset, error) {
+	var datasets []Dataset
+	err := s.client.performRequest(ctx, "GET", "/1/datasets", nil, &datasets)
+	return datasets, err
+}
+
+func (s datasets) Get(ctx context.Context, slug string) (*Dataset, error) {
+	var dataset Dataset
+	err := s.client.performRequest(ctx, "GET", "/1/datasets/"+slug, nil, &dataset)
+	return &dataset, err
+}
+
+func (s datasets) Create(ctx context.Context, data *Dataset) (*Dataset, error) {
+	var dataset Dataset
+	err := s.client.performRequest(ctx, "POST", "/1/datasets", data, &dataset)
+	return &dataset, err
+}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -1,0 +1,50 @@
+package honeycombio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatasets(t *testing.T) {
+	ctx := context.Background()
+
+	c := newTestClient(t)
+	datasetName := testDataset(t)
+
+	currentDataset := &Dataset{
+		Name: datasetName,
+		Slug: urlEncodeDataset(datasetName),
+	}
+
+	t.Run("List", func(t *testing.T) {
+		d, err := c.Datasets.List(ctx)
+
+		assert.NoError(t, err)
+		assert.Contains(t, d, *currentDataset, "could not find current dataset with List")
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		d, err := c.Datasets.Get(ctx, currentDataset.Slug)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *currentDataset, *d)
+	})
+
+	t.Run("Get_notFound", func(t *testing.T) {
+		_, err := c.Datasets.Get(ctx, "does-not-exist")
+
+		assert.Equal(t, ErrNotFound, err)
+	})
+
+	t.Run("Create", func(t *testing.T) {
+		createDataset := &Dataset{
+			Name: "kvrhdn/go-honeycombio",
+		}
+		d, err := c.Datasets.Create(ctx, createDataset)
+
+		assert.NoError(t, err)
+		assert.Equal(t, currentDataset, d)
+	})
+}

--- a/derived_column.go
+++ b/derived_column.go
@@ -1,0 +1,92 @@
+package honeycombio
+
+import (
+	"context"
+	"fmt"
+)
+
+// DerivedColumns describe all the derived columns-related methods that the
+// Honeycomb API supports.
+//
+// API docs: https://docs.honeycomb.io/api/derived_columns/
+type DerivedColumns interface {
+	// List all derived columns in this dataset.
+	List(ctx context.Context, dataset string) ([]DerivedColumn, error)
+
+	// Get a derived column by its ID. Returns ErrNotFound if there is no
+	// derived column with the given ID in this dataset.
+	Get(ctx context.Context, dataset string, id string) (*DerivedColumn, error)
+
+	// GetByAlias searches a derived column by its alias. Returns ErrNotFound if
+	// there is no derived column with the given alias in this dataset.
+	GetByAlias(ctx context.Context, dataset string, alias string) (*DerivedColumn, error)
+
+	// Create a new derived column in this dataset. When creating a new derived
+	// column ID may not be set. The Alias must be unique for this dataset.
+	Create(ctx context.Context, dataset string, d *DerivedColumn) (*DerivedColumn, error)
+
+	// Update an existing derived column.
+	Update(ctx context.Context, dataset string, d *DerivedColumn) (*DerivedColumn, error)
+
+	// Delete a derived column.
+	Delete(ctx context.Context, dataset string, id string) error
+}
+
+// derivedColumns implements DerivedColumns.
+type derivedColumns struct {
+	client *Client
+}
+
+// Compile-time proof of interface implementation by type derivedColumns.
+var _ DerivedColumns = (*derivedColumns)(nil)
+
+// Column represents a Honeycomb derived column in a dataset.
+//
+// API docs: https://docs.honeycomb.io/api/derived_columns/#fields-on-a-derivedcolumn
+type DerivedColumn struct {
+	ID string `json:"id,omitempty"`
+	// Alias of the derived column, this field is required and can not be
+	// updated.
+	Alias string `json:"alias"`
+	// Expression of the derived column, this field is required and can not be
+	// updated.
+	// This should be an expression following the Derived Column syntax, as
+	// described on https://docs.honeycomb.io/working-with-your-data/customizing-your-query/derived-columns/#derived-column-syntax
+	Expression string `json:"expression"`
+	// Optional.
+	Description string `json:"description,omitempty"`
+}
+
+func (s *derivedColumns) List(ctx context.Context, dataset string) ([]DerivedColumn, error) {
+	var c []DerivedColumn
+	err := s.client.performRequest(ctx, "GET", "/1/derived_columns/"+urlEncodeDataset(dataset), nil, &c)
+	return c, err
+}
+
+func (s *derivedColumns) Get(ctx context.Context, dataset string, id string) (*DerivedColumn, error) {
+	var c DerivedColumn
+	err := s.client.performRequest(ctx, "GET", fmt.Sprintf("/1/derived_columns/%s/%s", urlEncodeDataset(dataset), id), nil, &c)
+	return &c, err
+}
+
+func (s *derivedColumns) GetByAlias(ctx context.Context, dataset string, alias string) (*DerivedColumn, error) {
+	var c DerivedColumn
+	err := s.client.performRequest(ctx, "GET", fmt.Sprintf("/1/derived_columns/%s?alias=%s", urlEncodeDataset(dataset), alias), nil, &c)
+	return &c, err
+}
+
+func (s *derivedColumns) Create(ctx context.Context, dataset string, data *DerivedColumn) (*DerivedColumn, error) {
+	var d DerivedColumn
+	err := s.client.performRequest(ctx, "POST", "/1/derived_columns/"+urlEncodeDataset(dataset), data, &d)
+	return &d, err
+}
+
+func (s *derivedColumns) Update(ctx context.Context, dataset string, data *DerivedColumn) (*DerivedColumn, error) {
+	var d DerivedColumn
+	err := s.client.performRequest(ctx, "PUT", fmt.Sprintf("/1/derived_columns/%s/%s", urlEncodeDataset(dataset), data.ID), data, &d)
+	return &d, err
+}
+
+func (s *derivedColumns) Delete(ctx context.Context, dataset string, id string) error {
+	return s.client.performRequest(ctx, "DELETE", fmt.Sprintf("/1/derived_columns/%s/%s", urlEncodeDataset(dataset), id), nil, nil)
+}

--- a/derived_column_test.go
+++ b/derived_column_test.go
@@ -1,0 +1,87 @@
+package honeycombio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDerivedColumns(t *testing.T) {
+	ctx := context.Background()
+
+	c := newTestClient(t)
+	dataset := testDataset(t)
+
+	var derivedColumn *DerivedColumn
+	var err error
+
+	t.Run("Create", func(t *testing.T) {
+		data := &DerivedColumn{
+			Alias:       "derived_column_test",
+			Expression:  "LOG10($duration_ms)",
+			Description: "This derived column is created by a test",
+		}
+		derivedColumn, err = c.DerivedColumns.Create(ctx, dataset, data)
+
+		assert.NoError(t, err)
+
+		data.ID = derivedColumn.ID
+		assert.Equal(t, data, derivedColumn)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		derivedColumns, err := c.DerivedColumns.List(ctx, dataset)
+
+		assert.NoError(t, err)
+		assert.Contains(t, derivedColumns, *derivedColumn, "could not find DerivedColumn with List")
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		result, err := c.DerivedColumns.Get(ctx, dataset, derivedColumn.ID)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *derivedColumn, *result)
+	})
+
+	t.Run("GetByAlias", func(t *testing.T) {
+		result, err := c.DerivedColumns.GetByAlias(ctx, dataset, derivedColumn.Alias)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *derivedColumn, *result)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		// change all the fields to test
+		data := &DerivedColumn{
+			ID:          derivedColumn.ID,
+			Alias:       "derived_column_test_new_alias",
+			Expression:  "DIV($duration_ms, 2)",
+			Description: "This is a new description",
+		}
+		derivedColumn, err = c.DerivedColumns.Update(ctx, dataset, data)
+
+		assert.NoError(t, err)
+
+		data.ID = derivedColumn.ID
+		assert.Equal(t, data, derivedColumn)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		err = c.DerivedColumns.Delete(ctx, dataset, derivedColumn.ID)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("Get_notFound", func(t *testing.T) {
+		_, err := c.DerivedColumns.Get(ctx, dataset, derivedColumn.ID)
+
+		assert.Equal(t, ErrNotFound, err)
+	})
+
+	t.Run("GetByAlias_notFound", func(t *testing.T) {
+		_, err := c.DerivedColumns.GetByAlias(ctx, dataset, derivedColumn.Alias)
+
+		assert.Equal(t, ErrNotFound, err)
+	})
+}

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -1,7 +1,17 @@
 package honeycombio
 
+// BoolPtr returns a pointer to the given bool
+func BoolPtr(v bool) *bool {
+	return &v
+}
+
 // CalculationOpPtr returns a pointer to the given CalculationOp.
 func CalculationOpPtr(v CalculationOp) *CalculationOp {
+	return &v
+}
+
+// ColumnTypePtr returns a pointer to the given ColumnType.
+func ColumnTypePtr(v ColumnType) *ColumnType {
 	return &v
 }
 


### PR DESCRIPTION
Adds support for 3 new API's [Datasets](https://docs-ismith.honeycomb.io/api/datasets/), [Columns](https://docs-ismith.honeycomb.io/api/columns/) and [Derived Columns](https://docs-ismith.honeycomb.io/api/derived_columns/).

**Blocked**: the new APIs are currently in early access and deemed unstable, merge when released in beta.