### PR TITLE
Pass `disabled` on payload for trigger creates/updates

### DIFF
--- a/trigger.go
+++ b/trigger.go
@@ -50,7 +50,7 @@ type Trigger struct {
 	// Description is displayed on the triggers page.
 	Description string `json:"description,omitempty"`
 	// State of the trigger, if disabled is true the trigger will not run.
-	Disabled bool `json:"disabled,omitempty"`
+	Disabled bool `json:"disabled"`
 	// Query of the trigger. This field is required. The query must respect the
 	// properties described with and validated by MatchesTriggerSubset.
 	// Additionally, time_range of the query can be at most 1 day and may not


### PR DESCRIPTION
Currently, enabling disabled triggers via the `honeycombio` Terraform provider is not possible. This is because the `Triggers` client does not support `disabled: true ~> false` since a `false` value is always omitted on the payload. No matter how many applys we run, the Terraform plan always shows a diff on `disabled`.

We need the `"disabled" : false` field present on the `PUT` payload to the triggers endpoint in order to actually enable the alert. Let's not omit the field on the JSON marshal.
