### PR TITLE
Introduce new APIs: Query Results and Events

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,6 +69,7 @@ type Client struct {
 	Markers          Markers
 	Queries          Queries
 	QueryAnnotations QueryAnnotations
+	QueryResults     QueryResults
 	Triggers         Triggers
 }
 
@@ -103,6 +104,7 @@ func NewClient(config *Config) (*Client, error) {
 	client.Markers = &markers{client: client}
 	client.Queries = &queries{client: client}
 	client.QueryAnnotations = &queryAnnotations{client: client}
+	client.QueryResults = &queryResults{client: client}
 	client.Triggers = &triggers{client: client}
 
 	return client, nil

--- a/client.go
+++ b/client.go
@@ -66,6 +66,7 @@ type Client struct {
 	Columns          Columns
 	Datasets         Datasets
 	DerivedColumns   DerivedColumns
+	Events           Events
 	Markers          Markers
 	Queries          Queries
 	QueryAnnotations QueryAnnotations
@@ -101,6 +102,7 @@ func NewClient(config *Config) (*Client, error) {
 	client.Columns = &columns{client: client}
 	client.Datasets = &datasets{client: client}
 	client.DerivedColumns = &derivedColumns{client: client}
+	client.Events = &events{client: client}
 	client.Markers = &markers{client: client}
 	client.Queries = &queries{client: client}
 	client.QueryAnnotations = &queryAnnotations{client: client}

--- a/events.go
+++ b/events.go
@@ -1,0 +1,50 @@
+package honeycombio
+
+import (
+	"context"
+	"time"
+)
+
+// Events describe all the events-related methods that the Honeycomb API
+// supports.
+//
+// API docs: https://docs.honeycomb.io/api/events/
+type Events interface {
+	// Send a single event to this dataset.
+	Send(ctx context.Context, dataset string, data map[string]interface{}) error
+
+	// SendBatch sends batch of events to this dataset
+	SendBatch(ctx context.Context, dataset string, data []SendBatchRequest) ([]SendBatchResponse, error)
+}
+
+// events implements Events.
+type events struct {
+	client *Client
+}
+
+// Compile-time proof of interface implementation by type queries.
+var _ Events = (*events)(nil)
+
+// SendBatchRequest represents event batch request body
+type SendBatchRequest struct {
+	Time       *time.Time             `json:"time,omitempty"`
+	SampleRate int                    `json:"samplerate,omitempty"`
+	Data       map[string]interface{} `json:"data"`
+}
+
+// SendBatchRequest represents event batch response body
+type SendBatchResponse struct {
+	Status int `json:"status"`
+}
+
+// Send a single event to this dataset.
+func (s *events) Send(ctx context.Context, dataset string, data map[string]interface{}) error {
+	return s.client.performRequest(ctx, "POST", "/1/events/"+urlEncodeDataset(dataset), data, nil)
+}
+
+// SendBatch sends batch of events to this dataset
+func (s *events) SendBatch(ctx context.Context, dataset string, data []SendBatchRequest) ([]SendBatchResponse, error) {
+	var q []SendBatchResponse
+	err := s.client.performRequest(ctx, "POST", "/1/batch/"+urlEncodeDataset(dataset), data, &q)
+	return q, err
+}

--- a/events.go
+++ b/events.go
@@ -11,7 +11,7 @@ import (
 // API docs: https://docs.honeycomb.io/api/events/
 type Events interface {
 	// Send a single event to this dataset.
-	Send(ctx context.Context, dataset string, data map[string]interface{}) error
+	Send(ctx context.Context, dataset string, data interface{}) error
 
 	// SendBatch sends batch of events to this dataset
 	SendBatch(ctx context.Context, dataset string, data []SendBatchRequest) ([]SendBatchResponse, error)
@@ -27,9 +27,9 @@ var _ Events = (*events)(nil)
 
 // SendBatchRequest represents event batch request body
 type SendBatchRequest struct {
-	Time       *time.Time             `json:"time,omitempty"`
-	SampleRate int                    `json:"samplerate,omitempty"`
-	Data       map[string]interface{} `json:"data"`
+	Time       *time.Time  `json:"time,omitempty"`
+	SampleRate int         `json:"samplerate,omitempty"`
+	Data       interface{} `json:"data"`
 }
 
 // SendBatchRequest represents event batch response body
@@ -38,7 +38,7 @@ type SendBatchResponse struct {
 }
 
 // Send a single event to this dataset.
-func (s *events) Send(ctx context.Context, dataset string, data map[string]interface{}) error {
+func (s *events) Send(ctx context.Context, dataset string, data interface{}) error {
 	return s.client.performRequest(ctx, "POST", "/1/events/"+urlEncodeDataset(dataset), data, nil)
 }
 

--- a/events_test.go
+++ b/events_test.go
@@ -1,0 +1,64 @@
+package honeycombio
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type eventTestInput struct {
+	Column1    string  `json:"column_1"`
+	DurationMs float64 `json:"duration_ms"`
+}
+
+func TestEvents(t *testing.T) {
+	ctx := context.Background()
+
+	c := newTestClient(t)
+	dataset := testDataset(t)
+
+	t.Run("Send", func(t *testing.T) {
+		data := eventTestInput{
+			Column1:    "foo",
+			DurationMs: 1000,
+		}
+
+		err := c.Events.Send(ctx, dataset, data)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("SendBatch", func(t *testing.T) {
+		data := []SendBatchRequest{
+			{
+				Data: eventTestInput{
+					Column1:    "foo",
+					DurationMs: 1000,
+				},
+			},
+			{
+				Time:       TimePtr(time.Now()),
+				SampleRate: 2,
+				Data: eventTestInput{
+					Column1:    "bar",
+					DurationMs: 2000,
+				},
+			},
+		}
+
+		responses, err := c.Events.SendBatch(ctx, dataset, data)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, len(data), len(responses))
+		for _, response := range responses {
+			assert.Equal(t, 202, response.Status)
+		}
+	})
+}

--- a/query_results.go
+++ b/query_results.go
@@ -1,0 +1,68 @@
+package honeycombio
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// QueryResults describe all the query results-related methods that the Honeycomb API
+// supports.
+//
+// API docs: https://docs.honeycomb.io/api/query-results/
+type QueryResults interface {
+	// Get a query result by its ID.
+	//
+	// API docs: https://docs.honeycomb.io/api/query-results/#get-query-result
+	Get(ctx context.Context, dataset string, id string) (*QueryResult, error)
+
+	// Create a new result in this dataset. When creating a new query result ID may
+	// not be set.
+	//
+	// API docs: https://docs.honeycomb.io/api/query-results/#create-query-result
+	Create(ctx context.Context, dataset string, queryID string) (*QueryResult, error)
+}
+
+// queries implements Queries.
+type queryResults struct {
+	client *Client
+}
+
+// Compile-time proof of interface implementation by type queries.
+var _ QueryResults = (*queryResults)(nil)
+
+// QueryAnnotation represents a Honeycomb query result.
+//
+// API docs: https://docs.honeycomb.io/api/query-results/#get-example-response
+type QueryResult struct {
+	ID       string            `json:"id"`
+	Complete bool              `json:"complete"`
+	Data     *QueryResultData  `json:"data,omitempty"`
+	Links    *QueryResultLinks `json:"links,omitempty"`
+}
+
+type QueryResultData struct {
+	Series  json.RawMessage `json:"series"`
+	Results json.RawMessage `json:"results"`
+}
+
+type QueryResultLinks struct {
+	QueryURL      string `json:"query_url"`
+	GraphImageURL string `json:"graph_image_url"`
+}
+
+func (s *queryResults) Get(ctx context.Context, dataset string, id string) (*QueryResult, error) {
+	var q QueryResult
+	err := s.client.performRequest(ctx, "GET", fmt.Sprintf("/1/query_results/%s/%s", urlEncodeDataset(dataset), id), nil, &q)
+	return &q, err
+}
+
+func (s *queryResults) Create(ctx context.Context, dataset string, queryID string) (*QueryResult, error) {
+	var q QueryResult
+
+	data := map[string]string{
+		"query_id": queryID,
+	}
+	err := s.client.performRequest(ctx, "POST", "/1/query_results/"+urlEncodeDataset(dataset), data, &q)
+	return &q, err
+}

--- a/query_results_test.go
+++ b/query_results_test.go
@@ -1,0 +1,82 @@
+package honeycombio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryResults(t *testing.T) {
+	ctx := context.Background()
+
+	c := newTestClient(t)
+	dataset := testDataset(t)
+
+	var queryResult *QueryResult
+
+	t.Run("Create", func(t *testing.T) {
+		data := &QuerySpec{
+			Calculations: []CalculationSpec{
+				{
+					Op: CalculationOpCount,
+				},
+				{
+					Op:     CalculationOpHeatmap,
+					Column: StringPtr("duration_ms"),
+				},
+			},
+			Filters: []FilterSpec{
+				{
+					Column: "column_1",
+					Op:     FilterOpExists,
+				},
+				{
+					Column: "duration_ms",
+					Op:     FilterOpSmallerThan,
+					Value:  10000.0,
+				},
+			},
+			FilterCombination: FilterCombinationOr,
+			Breakdowns:        []string{"column_1", "column_2"},
+			Orders: []OrderSpec{
+				{
+					Column: StringPtr("column_1"),
+				},
+				{
+					Op:    CalculationOpPtr(CalculationOpCount),
+					Order: SortOrderPtr(SortOrderDesc),
+				},
+			},
+			Limit:       IntPtr(100),
+			TimeRange:   IntPtr(3600), // 1 hour
+			Granularity: IntPtr(60),   // 1 minute
+		}
+
+		query, err := c.Queries.Create(ctx, dataset, data)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		data.ID = query.ID
+		assert.Equal(t, data, query)
+
+		queryResult, err = c.QueryResults.Create(ctx, dataset, *query.ID)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		q, err := c.QueryResults.Get(ctx, dataset, queryResult.ID)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, queryResult.ID, q.ID)
+	})
+}

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -1,5 +1,7 @@
 package honeycombio
 
+import "time"
+
 // BoolPtr returns a pointer to the given bool
 func BoolPtr(v bool) *bool {
 	return &v
@@ -32,5 +34,10 @@ func SortOrderPtr(v SortOrder) *SortOrder {
 
 // StringPtr returns a pointer to the given string.
 func StringPtr(v string) *string {
+	return &v
+}
+
+// TimePtr returns a pointer to the given time.
+func TimePtr(v time.Time) *time.Time {
 	return &v
 }


### PR DESCRIPTION
This PR implements new APIs:
- [Query Results](https://docs.honeycomb.io/api/query-results/) (Enterprise only): get the aggregated data from a Query, similar to what is displayed in graphs or heatmaps within the Honeycomb UI.
- [Events](https://docs.honeycomb.io/api/events/): send individual events or send batch of events. 